### PR TITLE
	modified:   src/main/scala/com/github/scalazip/ZipReader.scala

### DIFF
--- a/src/main/scala/com/github/scalazip/ZipReader.scala
+++ b/src/main/scala/com/github/scalazip/ZipReader.scala
@@ -22,9 +22,11 @@ object ZipReader {
         val fileName = entry.getName
         val newFile = new File(output, fileName)
         new File(newFile.getParent).mkdir()
-        val fos = new FileOutputStream(newFile)
-        IOStream.stream(zis, fos)
-        fos.close()
+        if (! fileName.endsWith("/")) {
+          val fos = new FileOutputStream(newFile)
+          IOStream.stream(zis, fos)
+          fos.close()
+        }
       }
     zis.closeEntry()
     zis.close()


### PR DESCRIPTION
When the zip file include subpath , it could lead to java.io.FileNotFoundException in mac os X. 
