### PR TITLE
	modified:   src/main/scala/com/github/scalazip/ZipReader.scala

### DIFF
--- a/src/main/scala/com/github/scalazip/ZipReader.scala
+++ b/src/main/scala/com/github/scalazip/ZipReader.scala
@@ -21,7 +21,7 @@ object ZipReader {
       .foreach { entry =>
         val fileName = entry.getName
         val newFile = new File(output, fileName)
-        new File(newFile.getParent).mkdir()
+        new File(newFile.getParent).mkdirs()
         if (! fileName.endsWith("/")) {
           val fos = new FileOutputStream(newFile)
           IOStream.stream(zis, fos)


### PR DESCRIPTION
Fix a bug when exits long paths,use mkdirs instead mkdir.
